### PR TITLE
The last character of a string should be \0

### DIFF
--- a/src/input_code.c
+++ b/src/input_code.c
@@ -8,7 +8,7 @@ void input_code_init(InputCode *ic) {
 }
 
 void input_code_addline(InputCode *ic, const char *line) {
-  char *copy = malloc(sizeof(char) * strlen(line));
+  char *copy = malloc(sizeof(char) * (strlen(line) + 1));
   strcpy(copy, line);
   ic->lines[ic->line_count++] = copy;
 }

--- a/src/node.c
+++ b/src/node.c
@@ -71,7 +71,7 @@ static void parse_location(const char *s, union Location *loc, LocationType *typ
 
 static void parse_mov(Node *n, const char *s) {
   const int len = strlen(s+4);
-  char *rem = (char *) malloc(sizeof(char) * len);
+  char *rem = (char *) malloc(sizeof(char) * (len + 1));
   strcpy(rem, s+4);
 
   Instruction *i = node_create_instruction(n, MOV);
@@ -83,7 +83,7 @@ static void parse_mov(Node *n, const char *s) {
 
 static void parse_onearg(Node *n, InputCode *ic, const char *s, Operation op) {
   const int len = strlen(s+4);
-  char *rem = (char *) malloc(sizeof(char) * len);
+  char *rem = (char *) malloc(sizeof(char) * (len + 1));
   strcpy(rem, s+4);
 
   Instruction *ins = node_create_instruction(n, op);


### PR DESCRIPTION
This fixes a few of the errors shown on valgrind, although I'm not
sure if the '\0' character should be added manually to the end of the
strings.
