### PR TITLE
Fix segfault when using ANY

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -224,9 +224,11 @@ static inline Node *node_get_output_port(Node *n, int direction)
     LocationDirection dirs[] = {UP,LEFT,RIGHT,DOWN};
     for(int i=0; i < 4; i++) {
       Node *port = n->ports[dirs[i]];
-      Instruction *inst = &port->instructions[port->ip];
-      if (port && inst->operation == MOV && inst->src_type == ADDRESS && (inst->src.direction == ANY || port->ports[inst->src.direction] == n) ) {
-        return port;
+      if (port) {
+        Instruction *inst = &port->instructions[port->ip];
+        if (inst->operation == MOV && inst->src_type == ADDRESS && (inst->src.direction == ANY || port->ports[inst->src.direction] == n) ) {
+          return port;
+        }
       }
     }
     return NULL;


### PR DESCRIPTION
If port is null, the program attempts to read at an illegal address with port->ip. This check prevents a segfault from occurring.